### PR TITLE
Produce CSS in which local fonts are not used

### DIFF
--- a/R/css.R
+++ b/R/css.R
@@ -31,6 +31,8 @@ glue_css <- function(font_info, path = "../fonts/") {
 #' @param variants Variant of font to use.
 #' @param output Specifies path to output file for CSS generated.
 #' @param font_dir Fonts directory relative to \code{ouput}.
+#' @param prefer_local_source Generate CSS font-face rules in which user installed fonts are 
+#'     preferred. Use \code{FALSE} if you want to force the use of the downloaded font.  
 #'
 #' @return a character string with CSS code (invisibly)
 #' @export
@@ -41,18 +43,25 @@ glue_css <- function(font_info, path = "../fonts/") {
 #' cat(generate_css("roboto", "regular"))
 #'
 #' }
-generate_css <- function(id, variants = NULL, output = NULL, font_dir = "../fonts/") {
+generate_css <- function(id, variants = NULL, output = NULL, font_dir = "../fonts/", 
+                         prefer_local_source = TRUE) {
   font_info <- get_font_info(id = id)
   if (!is.null(variants)) {
     id <- font_info$variants$id
     font_info$variants <- font_info$variants[id %in% variants, ]
   }
   css <- glue_css(font_info = font_info, path = font_dir)
+  
+  if (!isTRUE(prefer_local_source)) {
+    css <- remove_local_src(css)
+  }
+  
   if (!is.null(output)) {
     writeLines(text = css, con = output)
   }
   invisible(css)
 }
 
-
-
+remove_local_src <- function(css) {
+  gsub("local\\('[^']+'),?[[:space:]]*", "", css)
+}

--- a/R/setup_font.R
+++ b/R/setup_font.R
@@ -4,6 +4,8 @@
 #' @param id Id of the font, correspond to column \code{id} from \code{\link{get_all_fonts}}.
 #' @param output_dir Output directory where to save font and CSS files. Must be a directory.
 #' @param variants Variant(s) to download, default is to includes all available ones.
+#' @param prefer_local_source Generate CSS font-face rules in which user installed fonts are 
+#'     preferred. Use \code{FALSE} if you want to force the use of the downloaded font.  
 #'
 #' @return To directories will be created (if they do not exist): \strong{fonts} and \strong{css}.
 #' @export
@@ -22,7 +24,7 @@
 #' )
 #'
 #' }
-setup_font <- function(id, output_dir, variants = NULL) {
+setup_font <- function(id, output_dir, variants = NULL, prefer_local_source = TRUE) {
 
   output_dir <- normalizePath(path = output_dir, mustWork = TRUE)
   dir_info <- file.info(output_dir)
@@ -47,7 +49,8 @@ setup_font <- function(id, output_dir, variants = NULL) {
     id = id,
     variants = variants,
     output = file.path(css_dir, paste0(id, ".css")),
-    font_dir = "../fonts/"
+    font_dir = "../fonts/",
+    prefer_local_source = prefer_local_source
   )
   usethis::ui_done("CSS generated")
 

--- a/man/generate_css.Rd
+++ b/man/generate_css.Rd
@@ -4,7 +4,13 @@
 \alias{generate_css}
 \title{Generate CSS to import fonts}
 \usage{
-generate_css(id, variants = NULL, output = NULL, font_dir = "../fonts/")
+generate_css(
+  id,
+  variants = NULL,
+  output = NULL,
+  font_dir = "../fonts/",
+  prefer_local_source = TRUE
+)
 }
 \arguments{
 \item{id}{Id of the font, correspond to column \code{id} from \code{\link{get_all_fonts}}.}
@@ -14,6 +20,9 @@ generate_css(id, variants = NULL, output = NULL, font_dir = "../fonts/")
 \item{output}{Specifies path to output file for CSS generated.}
 
 \item{font_dir}{Fonts directory relative to \code{ouput}.}
+
+\item{prefer_local_source}{Generate CSS font-face rules in which user installed fonts are 
+preferred. Use \code{FALSE} if you want to force the use of the downloaded font.}
 }
 \value{
 a character string with CSS code (invisibly)

--- a/man/setup_font.Rd
+++ b/man/setup_font.Rd
@@ -4,7 +4,7 @@
 \alias{setup_font}
 \title{Setup a font to be used in Shiny or Markdown}
 \usage{
-setup_font(id, output_dir, variants = NULL)
+setup_font(id, output_dir, variants = NULL, prefer_local_source = TRUE)
 }
 \arguments{
 \item{id}{Id of the font, correspond to column \code{id} from \code{\link{get_all_fonts}}.}
@@ -12,6 +12,9 @@ setup_font(id, output_dir, variants = NULL)
 \item{output_dir}{Output directory where to save font and CSS files. Must be a directory.}
 
 \item{variants}{Variant(s) to download, default is to includes all available ones.}
+
+\item{prefer_local_source}{Generate CSS font-face rules in which user installed fonts are 
+preferred. Use \code{FALSE} if you want to force the use of the downloaded font.}
 }
 \value{
 To directories will be created (if they do not exist): \strong{fonts} and \strong{css}.


### PR DESCRIPTION
Hi @pvictor, @mfanny,

Thanks a lot for this beautiful gem (as usual :wink:)!

This PR is a proposal to allow the user to remove the local source which is here:
https://github.com/dreamRs/gfonts/blob/7e921dfd587bdd3dbfe9bba9d24caf130cc3274a/inst/assets/templates/css_best.txt#L7

In fact, I have some use cases in which I need to remove the precedence of user installed fonts over downloaded fonts: 

- user installed font version is different than the downloaded font version. In this case, I want to force the use of the downloaded font and avoid the use of a local font. The goal is that the web page looks exactly the same for each user.
- self contained R Markdown documents: since the font is embedded in the document, the use of a local source is needless.  
